### PR TITLE
fix: fix pyproject version number to 0.1.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "school-manager"
-version = "0.1.0"
+version = "0.1.2"
 description = "A school manager api to manage courses, students and its enrollments"
 license = "GPL-3.0-only"
 authors = ["Marcos Raulino <marcosfsraulino@gmail.com>"]


### PR DESCRIPTION
## Description

Fix the project version number in the pyproject.toml file present in Pull Request #2 

## Changes Made

- Updated the pyproject version number to 0.1.2.

## Motivation and Context

After adding the contribution guide in pull request #2, it was noticed that the version number had been entered incorrectly in pyproject.toml (0.1.0). This fix ensures that the correct version (0.1.2) is set in the pyproject file.

Please review and merge this pull request at your earliest convenience. Feel free to provide any feedback or suggestions for improvement.